### PR TITLE
Simplification & bug-fix of _extract_setting

### DIFF
--- a/hey_fireball.py
+++ b/hey_fireball.py
@@ -123,21 +123,21 @@ class FireballMessage():
                     pass
 
     def _extract_setting(self):
-        if self.bot_is_first:
-            idx = 2
-            curPref = get_pm_preference(self.requestor_id)
-            if len(self.parts) < 3:
-                #Act as a toggle
-                if curPref:
-                    return 0
-                else:
-                    return 1
-            if self.parts[idx].lower() == 'on' and not curPref:
-                return 1
-            elif self.parts[idx].lower() == 'off' and curPref:
+        """Find the setting from self-targeting commands"""
+        idx = sum([bool(self.bot_is_first), bool(self.requestor_id)])
+        current_preference = get_pm_preference(self.requestor_id)
+        if 'on' in self.parts and not current_preference:
+            return 1
+        elif 'off' in self.parts and current_preference:
+            return 0
+        elif len(self.parts) == idx:
+            # No Arguments, act as a toggle:
+            if current_preference:
                 return 0
             else:
-                pass
+                return 1
+        else:
+            return 2
 
     '''
     # Use the following to catch and handle missing methods/properties as we want
@@ -315,11 +315,14 @@ def handle_command(fireball_message):
         send_message_to = fireball_message.requestor_id_only
 
     elif fireball_message.command == 'setpm':
-        set_pm_preference(fireball_message.requestor_id, fireball_message.setting)
-        if fireball_message.setting:
-            msg = "Receive PM's: On"
+        if fireball_message.setting <= 1:
+            set_pm_preference(fireball_message.requestor_id, fireball_message.setting)
+            if fireball_message.setting:
+                msg = "Receive PM's: On"
+            else:
+                msg = "Receive PM's: Off\n*Warning:* _Future messages that were sent only to you will look like this. This type of response does not typically persist between slack sessions._"
         else:
-            msg = "Receive PM's: Off\n*Warning:* _Future messages that were sent only to you will look like this. This type of response does not typically persist between slack sessions._"
+            msg = f"The option is already set as requested, or the argument was invalid.\nI accept: `{AT_BOT} setpm on`, `{AT_BOT} setpm off`, or `{AT_BOT} setpm` (to act as a toggle). "
         send_message_to = fireball_message.requestor_id_only
     else:
         # Message was not valid, so


### PR DESCRIPTION
There was the potential for an inconsistency in the event that a user passed any argument other than on/off.

It would cause things like having the bot pm the user the setpm off message because PM's were actually on for the user.

This patch prevents that issue by giving a third possible return value of 2. If '2' is returned, the bot will make no changes, inform the user that it can't understand the argument, and show the user the arguments that are accepted for the setpm command.

The _extract_setting method has also been updated to stop hardcoding indexes, matching the above \_extract\_** methods

<img width="892" alt="screen shot 2017-11-20 at 8 24 52 am" src="https://user-images.githubusercontent.com/20664010/33038661-01a5eef8-cdfb-11e7-9d85-d9a039b1a852.png">